### PR TITLE
Namespace changes adding zeek:: as well as zeek/ prefix for include f…

### DIFF
--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -1,12 +1,12 @@
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "AF_Packet.h"
 #include "RX_Ring.h"
 
 #include "af_packet.bif.h"
 
-using namespace iosource::pktsrc;
+using namespace af_packet::iosource::pktsrc;
 
 AF_PacketSource::~AF_PacketSource()
 	{
@@ -25,10 +25,10 @@ AF_PacketSource::AF_PacketSource(const std::string& path, bool is_live)
 
 void AF_PacketSource::Open()
 	{
-	uint64_t buffer_size = BifConst::AF_Packet::buffer_size;
-	bool enable_hw_timestamping = BifConst::AF_Packet::enable_hw_timestamping;
-	bool enable_fanout = BifConst::AF_Packet::enable_fanout;
-	bool enable_defrag = BifConst::AF_Packet::enable_defrag;
+	uint64_t buffer_size = zeek::BifConst::AF_Packet::buffer_size;
+	bool enable_hw_timestamping = zeek::BifConst::AF_Packet::enable_hw_timestamping;
+	bool enable_fanout = zeek::BifConst::AF_Packet::enable_fanout;
+	bool enable_defrag = zeek::BifConst::AF_Packet::enable_defrag;
 
 	socket_fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 
@@ -137,7 +137,7 @@ inline bool AF_PacketSource::ConfigureFanoutGroup(bool enabled, bool defrag)
 		uint32_t fanout_arg, fanout_id;
 		int ret;
 
-		fanout_id = BifConst::AF_Packet::fanout_id;
+		fanout_id = zeek::BifConst::AF_Packet::fanout_id;
 		fanout_arg = ((fanout_id & 0xffff) | (GetFanoutMode(defrag) << 16));
 
 		ret = setsockopt(socket_fd, SOL_PACKET, PACKET_FANOUT,
@@ -181,7 +181,7 @@ inline uint32_t AF_PacketSource::GetFanoutMode(bool defrag)
 	{
 	uint32_t fanout_mode;
 
-	switch ( BifConst::AF_Packet::fanout_mode->AsEnum() ) {
+	switch ( zeek::BifConst::AF_Packet::fanout_mode->AsEnum() ) {
 		case BifEnum::AF_Packet::FANOUT_CPU: fanout_mode = PACKET_FANOUT_CPU;
 			break;
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
@@ -210,7 +210,7 @@ void AF_PacketSource::Close()
 	Closed();
 	}
 
-bool AF_PacketSource::ExtractNextPacket(Packet* pkt)
+bool AF_PacketSource::ExtractNextPacket(zeek::Packet* pkt)
 	{
 	if ( ! socket_fd )
 		return false;
@@ -294,7 +294,7 @@ void AF_PacketSource::Statistics(Stats* s)
 	memcpy(s, &stats, sizeof(Stats));
 	}
 
-iosource::PktSrc* AF_PacketSource::InstantiateAF_Packet(const std::string& path, bool is_live)
+zeek::iosource::PktSrc* AF_PacketSource::InstantiateAF_Packet(const std::string& path, bool is_live)
 	{
 	return new AF_PacketSource(path, is_live);
 	}

--- a/src/AF_Packet.h
+++ b/src/AF_Packet.h
@@ -20,13 +20,12 @@ extern "C" {
 #include <pcap.h>
 }
 
-#include "iosource/PktSrc.h"
+#include "zeek/iosource/PktSrc.h"
 #include "RX_Ring.h"
 
-namespace iosource {
-namespace pktsrc {
+namespace af_packet::iosource::pktsrc {
 
-class AF_PacketSource : public iosource::PktSrc {
+class AF_PacketSource : public zeek::iosource::PktSrc {
 public:
 	/**
 	 * Constructor.
@@ -50,7 +49,7 @@ protected:
 	// PktSrc interface.
 	virtual void Open();
 	virtual void Close();
-	virtual bool ExtractNextPacket(Packet* pkt);
+	virtual bool ExtractNextPacket(zeek::Packet* pkt);
 	virtual void DoneWithPacket();
 	virtual bool PrecompileFilter(int index, const std::string& filter);
 	virtual bool SetFilter(int index);
@@ -74,7 +73,6 @@ private:
 	uint32_t GetFanoutMode(bool defrag=false);
 };
 
-}
 }
 
 #endif

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,17 +1,17 @@
 
 #include "Plugin.h"
 #include "AF_Packet.h"
-#include "iosource/Component.h"
+#include "zeek/iosource/Component.h"
 
-namespace plugin { namespace Zeek_AF_Packet { Plugin plugin; } }
+namespace af_packet::plugin::Zeek_AF_Packet { Plugin plugin; }
 
-using namespace plugin::Zeek_AF_Packet;
+using namespace af_packet::plugin::Zeek_AF_Packet;
 
-plugin::Configuration Plugin::Configure()
+zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new ::iosource::PktSrcComponent("AF_PacketReader", "af_packet", ::iosource::PktSrcComponent::LIVE, ::iosource::pktsrc::AF_PacketSource::InstantiateAF_Packet));
+	AddComponent(new ::zeek::iosource::PktSrcComponent("AF_PacketReader", "af_packet", ::zeek::iosource::PktSrcComponent::LIVE, ::af_packet::iosource::pktsrc::AF_PacketSource::InstantiateAF_Packet));
 
-	plugin::Configuration config;
+	zeek::plugin::Configuration config;
 	config.name = "Zeek::AF_Packet";
 	config.description = "Packet acquisition via AF_Packet";
 	config.version.major = 2;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -2,21 +2,19 @@
 #ifndef ZEEK_PLUGIN_ZEEK_AF_PACKET
 #define ZEEK_PLUGIN_ZEEK_AF_PACKET
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
 
-namespace plugin {
-namespace Zeek_AF_Packet {
+namespace af_packet::plugin::Zeek_AF_Packet {
 
-class Plugin : public ::plugin::Plugin
+class Plugin : public zeek::plugin::Plugin
 {
 protected:
-	// Overridden from plugin::Plugin.
-	plugin::Configuration Configure() override;
+	// Overridden from zeek::plugin::Plugin.
+	zeek::plugin::Configuration Configure() override;
 };
 
 extern Plugin plugin;
 
-}
 }
 
 #endif


### PR DESCRIPTION
…iles.

There are changes in master that break a lot of plugins.   This is the first fix I've attempted to make and I'm not sure how old of a version of zeek it will continue to work with.