### PR TITLE
Fix namespace usage to support Zeek 4.0+

### DIFF
--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -1,12 +1,12 @@
 
-#include "zeek-config.h"
+#include "zeek/zeek-config.h"
 
 #include "AF_Packet.h"
 #include "RX_Ring.h"
 
 #include "af_packet.bif.h"
 
-using namespace iosource::pktsrc;
+using namespace zeek::iosource::pktsrc;
 
 AF_PacketSource::~AF_PacketSource()
 	{
@@ -294,7 +294,7 @@ void AF_PacketSource::Statistics(Stats* s)
 	memcpy(s, &stats, sizeof(Stats));
 	}
 
-iosource::PktSrc* AF_PacketSource::InstantiateAF_Packet(const std::string& path, bool is_live)
+zeek::iosource::PktSrc* AF_PacketSource::InstantiateAF_Packet(const std::string& path, bool is_live)
 	{
 	return new AF_PacketSource(path, is_live);
 	}

--- a/src/AF_Packet.h
+++ b/src/AF_Packet.h
@@ -20,11 +20,10 @@ extern "C" {
 #include <pcap.h>
 }
 
-#include "iosource/PktSrc.h"
+#include "zeek/iosource/PktSrc.h"
 #include "RX_Ring.h"
 
-namespace iosource {
-namespace pktsrc {
+namespace zeek::iosource::pktsrc {
 
 class AF_PacketSource : public iosource::PktSrc {
 public:
@@ -74,7 +73,6 @@ private:
 	uint32_t GetFanoutMode(bool defrag=false);
 };
 
-}
 }
 
 #endif

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,17 +1,17 @@
 
 #include "Plugin.h"
 #include "AF_Packet.h"
-#include "iosource/Component.h"
+#include "zeek/iosource/Component.h"
 
 namespace plugin { namespace Zeek_AF_Packet { Plugin plugin; } }
 
 using namespace plugin::Zeek_AF_Packet;
 
-plugin::Configuration Plugin::Configure()
+zeek::plugin::Configuration Plugin::Configure()
 	{
-	AddComponent(new ::iosource::PktSrcComponent("AF_PacketReader", "af_packet", ::iosource::PktSrcComponent::LIVE, ::iosource::pktsrc::AF_PacketSource::InstantiateAF_Packet));
+	AddComponent(new zeek::iosource::PktSrcComponent("AF_PacketReader", "af_packet", zeek::iosource::PktSrcComponent::LIVE, zeek::iosource::pktsrc::AF_PacketSource::InstantiateAF_Packet));
 
-	plugin::Configuration config;
+	zeek::plugin::Configuration config;
 	config.name = "Zeek::AF_Packet";
 	config.description = "Packet acquisition via AF_Packet";
 	config.version.major = 2;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -2,16 +2,16 @@
 #ifndef ZEEK_PLUGIN_ZEEK_AF_PACKET
 #define ZEEK_PLUGIN_ZEEK_AF_PACKET
 
-#include <plugin/Plugin.h>
+#include "zeek/plugin/Plugin.h"
 
 namespace plugin {
 namespace Zeek_AF_Packet {
 
-class Plugin : public ::plugin::Plugin
+class Plugin : public zeek::plugin::Plugin
 {
 protected:
 	// Overridden from plugin::Plugin.
-	plugin::Configuration Configure() override;
+	zeek::plugin::Configuration Configure() override;
 };
 
 extern Plugin plugin;


### PR DESCRIPTION
This fixes issues with include paths and namespace usage when building against Zeek 4.0 and above.