### PR TITLE
Explicitly set script_dir in zkg.meta

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -1,6 +1,7 @@
 [package]
 description = This plugin provides native AF_Packet support for Zeek.
 tags = zeek plugin, zeekctl plugin, packet source, af_packet
+script_dir = scripts
 plugin_dir = build/Zeek_AF_Packet.tgz
 build_command = ./configure && make
 test_command = cd tests && btest -d


### PR DESCRIPTION
This avoids the following warning when installing the master branch of this package:

> `no __load__.zeek in implicit script_dir, skipped installing scripts`