### PR TITLE
Support hardware checksum offloading, only available in zeek 3.2+

### DIFF
--- a/README
+++ b/README
@@ -25,13 +25,15 @@ If everything built and installed correctly, you should see this:
     Zeek::AF_Packet - Packet acquisition via AF_Packet (dynamic, version 3.2.0)
     [Packet Source] AF_PacketReader (interface prefix "af_packet"; supports live input)
     [Type] AF_Packet::FanoutMode
+    [Type] AF_Packet::ChecksumMode
     [Constant] AF_Packet::buffer_size
     [Constant] AF_Packet::enable_hw_timestamping
-    [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::enable_defrag
+    [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::fanout_mode
     [Constant] AF_Packet::fanout_id
     [Constant] AF_Packet::link_type
+    [Constant] AF_Packet::checksum_validation_mode
 
 ## Upgrade from Bro to Zeek
 

--- a/configure
+++ b/configure
@@ -175,8 +175,8 @@ if [ "$installroot" != "default" ]; then
     append_cache_entry BRO_PLUGIN_INSTALL_ROOT PATH $installroot
 fi
 
-echo "Build Directory              : $builddir"
-echo "Zeek Source Directory        : $zeekdist"
+echo "Build Directory         : $builddir"
+echo "Zeek Source Directory   : $zeekdist"
 
 mkdir -p $builddir
 cd $builddir

--- a/configure
+++ b/configure
@@ -175,8 +175,8 @@ if [ "$installroot" != "default" ]; then
     append_cache_entry BRO_PLUGIN_INSTALL_ROOT PATH $installroot
 fi
 
-echo "Build Directory        : $builddir"
-echo "Zeek Source Directory   : $zeekdist"
+echo "Build Directory              : $builddir"
+echo "Zeek Source Directory        : $zeekdist"
 
 mkdir -p $builddir
 cd $builddir

--- a/scripts/init.zeek
+++ b/scripts/init.zeek
@@ -5,17 +5,6 @@
 module AF_Packet;
 
 export {
-	# The various modes of checksum offloading. OFF means we will set the
-	# checksum variables to true, trusting that they are correct no matter
-	# what the kernel or zeek thinks. ON means we will ignore the kernel
-	# checksums and let Zeek check them. KERNEL means we will trust the
-	# kernel checksums and let Zeek skip checking them.
-	type Checksum_Mode : enum {
-		OFF,
-		ON,
-		KERNEL
-	};
-
 	## Size of the ring-buffer.
 	const buffer_size = 128 * 1024 * 1024 &redef;
 	## Toggle whether to use hardware timestamps.
@@ -24,12 +13,12 @@ export {
 	const enable_fanout = T &redef;
 	## Toggle defragmentation of IP packets using PACKET_FANOUT_FLAG_DEFRAG.
 	const enable_defrag = F &redef;
-	## Fanout Mode.
+	## Fanout mode.
 	const fanout_mode = FANOUT_HASH &redef;
 	## Fanout ID.
 	const fanout_id = 23 &redef;
 	## Link type (default Ethernet).
 	const link_type = 1 &redef;
-	## Checksum offloading option.
-	const checksum_offloading_mode: Checksum_Mode = KERNEL &redef;
+	## Checksum validation mode.
+	const checksum_validation_mode: ChecksumMode = CHECKSUM_ON &redef;
 }

--- a/scripts/init.zeek
+++ b/scripts/init.zeek
@@ -5,6 +5,17 @@
 module AF_Packet;
 
 export {
+	# The various modes of checksum offloading. OFF means we will set the
+	# checksum variables to true, trusting that they are correct no matter
+	# what the kernel or zeek thinks. ON means we will ignore the kernel
+	# checksums and let Zeek check them. KERNEL means we will trust the
+	# kernel checksums and let Zeek skip checking them.
+	type Checksum_Mode : enum {
+		OFF,
+		ON,
+		KERNEL
+	};
+
 	## Size of the ring-buffer.
 	const buffer_size = 128 * 1024 * 1024 &redef;
 	## Toggle whether to use hardware timestamps.
@@ -19,4 +30,6 @@ export {
 	const fanout_id = 23 &redef;
 	## Link type (default Ethernet).
 	const link_type = 1 &redef;
+	## Checksum offloading option.
+	const checksum_offloading_mode: Checksum_Mode = KERNEL &redef;
 }

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -22,7 +22,7 @@ AF_PacketSource::AF_PacketSource(const std::string& path, bool is_live)
 	props.path = path;
 	props.is_live = is_live;
 
-	checksum_mode = zeek::BifConst::AF_Packet::checksum_offloading_mode->AsEnum();
+	checksum_mode = zeek::BifConst::AF_Packet::checksum_validation_mode->AsEnum();
 	}
 
 void AF_PacketSource::Open()
@@ -281,8 +281,6 @@ bool AF_PacketSource::ExtractNextPacket(zeek::Packet* pkt)
 				break;
 				}
 			}
-#else
-		fprintf(stderr, "bad version?\n");
 #endif
 
 		if ( current_hdr.len == 0 || current_hdr.caplen == 0 )

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -21,12 +21,15 @@ AF_PacketSource::AF_PacketSource(const std::string& path, bool is_live)
 	current_filter = -1;
 	props.path = path;
 	props.is_live = is_live;
+
+	checksum_mode = zeek::BifConst::AF_Packet::checksum_offloading_mode->AsEnum();
 	}
 
 void AF_PacketSource::Open()
 	{
 	uint64_t buffer_size = zeek::BifConst::AF_Packet::buffer_size;
 	int link_type = zeek::BifConst::AF_Packet::link_type;
+
 	bool enable_hw_timestamping = zeek::BifConst::AF_Packet::enable_hw_timestamping;
 	bool enable_fanout = zeek::BifConst::AF_Packet::enable_fanout;
 	bool enable_defrag = zeek::BifConst::AF_Packet::enable_defrag;
@@ -248,6 +251,39 @@ bool AF_PacketSource::ExtractNextPacket(zeek::Packet* pkt)
 
 		if ( packet->tp_status & TP_STATUS_VLAN_VALID )
 			pkt->vlan = packet->hv1.tp_vlan_tci;
+
+#if ZEEK_VERSION_NUMBER >= 50100
+		switch ( checksum_mode )
+			{
+			case BifEnum::AF_Packet::CHECKSUM_OFF:
+				{
+				// If set to off, just accept whatever checksum in the packet is correct and
+				// skip checking it here and in Zeek.
+				pkt->l4_checksummed = true;
+				break;
+				}
+			case BifEnum::AF_Packet::CHECKSUM_KERNEL:
+				{
+				// If set to kernel, check whether the kernel thinks the checksum is valid. If it
+				// does, tell Zeek to skip checking by itself.
+				if ( ( (packet->tp_status & TP_STATUS_CSUM_VALID) != 0 ) ||
+				     ( (packet->tp_status & TP_STATUS_CSUMNOTREADY) != 0 ) )
+					pkt->l4_checksummed = true;
+				else
+					pkt->l4_checksummed = false;
+				break;
+				}
+			case BifEnum::AF_Packet::CHECKSUM_ON:
+			default:
+				{
+				// Let Zeek handle it.
+				pkt->l4_checksummed = false;
+				break;
+				}
+			}
+#else
+		fprintf(stderr, "bad version?\n");
+#endif
 
 		if ( current_hdr.len == 0 || current_hdr.caplen == 0 )
 			{

--- a/src/AF_Packet.h
+++ b/src/AF_Packet.h
@@ -60,6 +60,7 @@ private:
 
 	int current_filter;
 	unsigned int num_discarded;
+	int checksum_mode;
 
 	int socket_fd;
 	RX_Ring *rx_ring;

--- a/src/af_packet.bif
+++ b/src/af_packet.bif
@@ -3,6 +3,7 @@
 
 module AF_Packet;
 
+## Available fanout modes.
 enum FanoutMode %{
 	FANOUT_HASH, # PACKET_FANOUT_HASH
 	FANOUT_CPU,  # PACKET_FANOUT_CPU
@@ -11,17 +12,22 @@ enum FanoutMode %{
 	FANOUT_EBPF, # PACKET_FANOUT_EBPF
 %}
 
+## Available checksum validation modes.
 enum ChecksumMode %{
+	## Ignore checksums, i.e. always assume they are correct.
 	CHECKSUM_OFF,
+	## Let Zeek compute and verify checksums.
 	CHECKSUM_ON,
+	## Let the kernel handle checksum offloading.
+	## Note: Semantics may depend on the kernel and driver version.
 	CHECKSUM_KERNEL,
 %}
 
 const buffer_size: count;
 const enable_hw_timestamping: bool;
-const enable_fanout: bool;
 const enable_defrag: bool;
+const enable_fanout: bool;
 const fanout_mode: FanoutMode;
 const fanout_id: count;
 const link_type: count;
-const checksum_offloading_mode: ChecksumMode;
+const checksum_validation_mode: ChecksumMode;

--- a/src/af_packet.bif
+++ b/src/af_packet.bif
@@ -11,6 +11,12 @@ enum FanoutMode %{
 	FANOUT_EBPF, # PACKET_FANOUT_EBPF
 %}
 
+enum ChecksumMode %{
+	CHECKSUM_OFF,
+	CHECKSUM_ON,
+	CHECKSUM_KERNEL,
+%}
+
 const buffer_size: count;
 const enable_hw_timestamping: bool;
 const enable_fanout: bool;
@@ -18,3 +24,4 @@ const enable_defrag: bool;
 const fanout_mode: FanoutMode;
 const fanout_id: count;
 const link_type: count;
+const checksum_offloading_mode: ChecksumMode;

--- a/tests/Baseline/scripts.show-plugin/output
+++ b/tests/Baseline/scripts.show-plugin/output
@@ -2,11 +2,13 @@
 Zeek::AF_Packet - Packet acquisition via AF_Packet (dynamic, version)
     [Packet Source] AF_PacketReader (interface prefix "af_packet"; supports live input)
     [Type] AF_Packet::FanoutMode
+    [Type] AF_Packet::ChecksumMode
     [Constant] AF_Packet::buffer_size
     [Constant] AF_Packet::enable_hw_timestamping
-    [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::enable_defrag
+    [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::fanout_mode
     [Constant] AF_Packet::fanout_id
     [Constant] AF_Packet::link_type
+    [Constant] AF_Packet::checksum_validation_mode
 


### PR DESCRIPTION
I've had this patch sitting in a fork for a while and @sethhall reminded me that I never actually opened a PR to upstream it.

This PR adds support for handling hardware checksumming from af_packet and passing that information to zeek to allow it to skip the internal checksums.