### PR TITLE
Avoid Zeek script double-loading problems

### DIFF
--- a/scripts/af_packet/__load__.zeek
+++ b/scripts/af_packet/__load__.zeek
@@ -1,0 +1,1 @@
+# This package currently doesn't have any generic script functionality.

--- a/zkg.meta
+++ b/zkg.meta
@@ -1,7 +1,7 @@
 [package]
 description = This plugin provides native AF_Packet support for Zeek.
 tags = zeek plugin, zeekctl plugin, packet source, af_packet
-script_dir = scripts
+scripts = scripts/af_packet
 plugin_dir = build/Zeek_AF_Packet.tgz
 build_command = ./configure && make
 test_command = cd tests && btest -d


### PR DESCRIPTION
When you install versions of the package >= 3.0, running Zeek with the installed package throws a bunch of warnings:

```
$ zkg install zeek-af_packet-plugin
The following packages will be INSTALLED:
  zeek/j-gras/zeek-af_packet-plugin (3.0.1)

Proceed? [Y/n]
Running unit tests for "zeek/j-gras/zeek-af_packet-plugin"
Installing "zeek/j-gras/zeek-af_packet-plugin"...
Installed "zeek/j-gras/zeek-af_packet-plugin" (3.0.1)
Loaded "zeek/j-gras/zeek-af_packet-plugin"

$ zeek packages
warning in /home/christian/inst/opt/zeek/lib64/zeek/plugins/packages/zeek-af_packet-plugin/scripts/./init.zeek, line 9 and /home/christian/inst/opt/zeek/share/zeek/site/packages/./zeek-af_packet-plugin/./init.zeek, line 9: redefinition requires "redef" (AF_Packet::buffer_size)
warning in /home/christian/inst/opt/zeek/share/zeek/site/packages/./zeek-af_packet-plugin/./init.zeek, line 9: Duplicate identifier documentation: AF_Packet::buffer_size
warning in /home/christian/inst/opt/zeek/lib64/zeek/plugins/packages/zeek-af_packet-plugin/scripts/./init.zeek, line 11 and /home/christian/inst/opt/zeek/share/zeek/site/packages/./zeek-af_packet-plugin/./init.zeek, line 11: redefinition requires "redef" (AF_Packet::enable_hw_timestamping)
warning in /home/christian/inst/opt/zeek/share/zeek/site/packages/./zeek-af_packet-plugin/./init.zeek, line 11: Duplicate identifier documentation: AF_Packet::enable_hw_timestamping
warning in /home/christian/inst/opt/zeek/lib64/zeek/plugins/packages/zeek-af_packet-plugin/scripts/./init.zeek, line 13 and /home/christian/inst/opt/zeek/share/zeek/site/packages/./zeek-af_packet-plugin/./init.zeek, line 13: redefinition requires "redef" (AF_Packet::enable_fanout)
...
```

It does actually run, but that's just luck — with more severe script-level clashes it'd bail out. The problem is that the package has an unintentional double-use of the scripts folder: the plugin machinery automatically picks it as its location of Zeek scripts required for the plugin to function, and `zkg`'s packaging also picks it up via the explicit instruction in `zkg.meta`.

This PR simply moves the package-level stuff to a subdirectory, as a placeholder. That placeholder still avoids the warning that e3aea14a84c505367cd6277c67b6def2f5ea9d5f wanted to fix.