### PR TITLE
Make block_size and block_timeout configurable

### DIFF
--- a/README
+++ b/README
@@ -26,6 +26,8 @@ If everything built and installed correctly, you should see this:
     [Packet Source] AF_PacketReader (interface prefix "af_packet"; supports live input)
     [Type] AF_Packet::FanoutMode
     [Constant] AF_Packet::buffer_size
+    [Constant] AF_Packet::block_size
+    [Constant] AF_Packet::block_timeout
     [Constant] AF_Packet::enable_hw_timestamping
     [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::enable_defrag

--- a/scripts/init.zeek
+++ b/scripts/init.zeek
@@ -7,6 +7,11 @@ module AF_Packet;
 export {
 	## Size of the ring-buffer.
 	const buffer_size = 128 * 1024 * 1024 &redef;
+	## Size of an individual block. Needs to be a multiple of page size.
+	## Defaults to 32KB.
+	const block_size = 4096 * 8 &redef;
+	## Retire timeout for a single block. Default is 10msec.
+	const block_timeout = 10msec &redef;
 	## Toggle whether to use hardware timestamps.
 	const enable_hw_timestamping = F &redef;
 	## Toggle whether to use PACKET_FANOUT.

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -26,6 +26,8 @@ AF_PacketSource::AF_PacketSource(const std::string& path, bool is_live)
 void AF_PacketSource::Open()
 	{
 	uint64_t buffer_size = zeek::BifConst::AF_Packet::buffer_size;
+	uint64_t block_size = zeek::BifConst::AF_Packet::block_size;
+	int block_timeout_msec = static_cast<int>(zeek::BifConst::AF_Packet::block_timeout * 1000.0);
 	int link_type = zeek::BifConst::AF_Packet::link_type;
 	bool enable_hw_timestamping = zeek::BifConst::AF_Packet::enable_hw_timestamping;
 	bool enable_fanout = zeek::BifConst::AF_Packet::enable_fanout;
@@ -41,7 +43,7 @@ void AF_PacketSource::Open()
 
 	// Create RX-ring
 	try {
-		rx_ring = new RX_Ring(socket_fd, buffer_size);
+		rx_ring = new RX_Ring(socket_fd, buffer_size, block_size, block_timeout_msec);
 	} catch (RX_RingException& e) {
 		Error(errno ? strerror(errno) : "unable to create RX-ring");
 		close(socket_fd);

--- a/src/RX_Ring.h
+++ b/src/RX_Ring.h
@@ -21,14 +21,14 @@ public:
 	/**
 	 * Constructor
 	 */
-	RX_Ring(int sock, size_t bufsize);
+	RX_Ring(int sock, size_t bufsize, size_t blocksize, int blocktimeout_msec);
 	~RX_Ring();
 
 	bool GetNextPacket(tpacket3_hdr** hdr);
 	void ReleasePacket();
 
 protected:
-	void InitLayout(size_t bufsize);
+	void InitLayout(size_t bufsize, size_t blocksize, int blocktimeout_msec);
 	void NextBlock();
 
 private:

--- a/src/af_packet.bif
+++ b/src/af_packet.bif
@@ -12,6 +12,8 @@ enum FanoutMode %{
 %}
 
 const buffer_size: count;
+const block_size: count;
+const block_timeout: interval;
 const enable_hw_timestamping: bool;
 const enable_fanout: bool;
 const enable_defrag: bool;

--- a/tests/Baseline/scripts.show-plugin/output
+++ b/tests/Baseline/scripts.show-plugin/output
@@ -3,6 +3,8 @@ Zeek::AF_Packet - Packet acquisition via AF_Packet (dynamic, version)
     [Packet Source] AF_PacketReader (interface prefix "af_packet"; supports live input)
     [Type] AF_Packet::FanoutMode
     [Constant] AF_Packet::buffer_size
+    [Constant] AF_Packet::block_size
+    [Constant] AF_Packet::block_timeout
     [Constant] AF_Packet::enable_hw_timestamping
     [Constant] AF_Packet::enable_fanout
     [Constant] AF_Packet::enable_defrag


### PR DESCRIPTION
This lowers the default timeout from 100msec to 10msec and increases the default block_size from 16KB to 32KB. Both are aligned with what Suricata uses as defaults.

The block_size is likely too conservative for high-performance, tuning guides recommend starting with 1MB block size.

Fixes #37.