### PR TITLE
Fix enable_defrag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(ZeekPluginAF_Packet)
 
 include(ZeekPlugin)
 
+add_compile_options(-Wunused -Werror)
+
 zeek_plugin_begin(Zeek AF_Packet)
 zeek_plugin_cc(src/Plugin.cc)
 zeek_plugin_cc(src/AF_Packet.cc)

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -226,7 +226,6 @@ bool AF_PacketSource::ExtractNextPacket(zeek::Packet* pkt)
 
 	struct tpacket3_hdr *packet = 0;
 	const u_char *data;
-	struct timeval ts;
 	while ( true )
 		{
 		if ( ! rx_ring->GetNextPacket(&packet) )

--- a/src/AF_Packet.cc
+++ b/src/AF_Packet.cc
@@ -63,7 +63,7 @@ void AF_PacketSource::Open()
 		return;
 		}
 
-	if ( ! ConfigureFanoutGroup(enable_fanout) )
+	if ( ! ConfigureFanoutGroup(enable_fanout, enable_defrag) )
 		{
 		Error(errno ? strerror(errno) : "failed to join fanout group");
 		close(socket_fd);

--- a/src/AF_Packet.h
+++ b/src/AF_Packet.h
@@ -67,9 +67,9 @@ private:
 
 	bool BindInterface();
 	bool EnablePromiscMode();
-	bool ConfigureFanoutGroup(bool enabled, bool defrag=false);
+	bool ConfigureFanoutGroup(bool enabled, bool defrag);
 	bool ConfigureHWTimestamping(bool enabled);
-	uint32_t GetFanoutMode(bool defrag=false);
+	uint32_t GetFanoutMode(bool defrag);
 };
 
 }


### PR DESCRIPTION
Seems enable_defrag was never actually passed down to the relevant functions.
Remove the default parameters to ensure we properly pass it down.

