### PR TITLE
Remove compile_options() again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(ZeekPluginAF_Packet)
 
 include(ZeekPlugin)
 
-add_compile_options(-Wunused -Werror)
-
 zeek_plugin_begin(Zeek AF_Packet)
 zeek_plugin_cc(src/Plugin.cc)
 zeek_plugin_cc(src/AF_Packet.cc)


### PR DESCRIPTION
This seems to trickle through to base Zeek code when done like that.

https://cirrus-ci.com/task/4788073346105344?logs=build#L2298