### PR TITLE
RX_Ring: Remove extra blocks data structure

### DIFF
--- a/src/RX_Ring.h
+++ b/src/RX_Ring.h
@@ -34,7 +34,6 @@ protected:
 
 private:
 	struct tpacket_req3 layout;
-	struct tpacket_block_desc** blocks;
 	struct tpacket3_hdr* packet;
 
 	unsigned int block_num;
@@ -42,6 +41,11 @@ private:
 
 	uint8_t* ring;
 	size_t size;
+
+	// Return a pointer to the tpacket_block_desc of block num.
+	struct tpacket_block_desc* get_block_desc_ptr(unsigned int num) {
+		return (struct tpacket_block_desc*)(ring + num * layout.tp_block_size);
+	}
 };
 
 #endif


### PR DESCRIPTION
Okay, this might be naive. Both Suricata and the AF_PACKET example [1] keep the block descriptor offsets in a separately allocated table as well.

From all I can tell, that allocation isn't really needed if we're okay computing the address of the block based on the beginning of the mmap'ed memory region using the tp_req parameters. That shouldn't be slower

[1] https://docs.kernel.org/networking/packet_mmap.html#af-packet-tpacket-v3-example