### PR TITLE
Make all options available via zeekctl

### DIFF
--- a/README
+++ b/README
@@ -92,6 +92,8 @@ If all interfaces using `lb_method=custom` should be configured for AF_Packet, t
 
     lb_custom.InterfacePrefix=af_packet::
 
+Note that all configuration options described in the [configuration section](#advanced-configuration) can be set via `zeekctl`. The key is formed by prepending `af_packet_` to the option name.
+
 ## Advanced Configuration
 
 While the plugin aims at providing a "plug and play" user experience, it exposes several configuration options of the underlying API for customization (see [init.zeek](scripts/init.zeek) for the default values):

--- a/zeekctl/af_packet.py
+++ b/zeekctl/af_packet.py
@@ -19,7 +19,18 @@ class AF_Packet(ZeekControl.plugin.Plugin):
 		return False
 
 	def nodeKeys(self):
-		return ["fanout_id", "fanout_mode", "buffer_size"]
+		return [
+			"buffer_size",
+			"block_size",
+			"block_timeout",
+			"enable_hw_timestamping",
+			"enable_fanout",
+			"enable_defrag",
+			"fanout_mode",
+			"fanout_id",
+			"link_type",
+			"checksum_validation_mode",
+			]
 
 	def zeekctl_config(self):
 		script = ""
@@ -31,12 +42,9 @@ class AF_Packet(ZeekControl.plugin.Plugin):
 
 			params = ""
 
-			if nn.af_packet_fanout_id:
-				params += "\n  redef AF_Packet::fanout_id = %s;" % nn.af_packet_fanout_id
-			if nn.af_packet_fanout_mode:
-				params += "\n  redef AF_Packet::fanout_mode = %s;" % nn.af_packet_fanout_mode
-			if nn.af_packet_buffer_size:
-				params += "\n  redef AF_Packet::buffer_size = %s;" % nn.af_packet_buffer_size
+			for p, v in vars(nn).items():
+				if p.startswith('af_packet_') and v:
+					params += f"\n  redef AF_Packet::{p[10:]} = {v};"
 
 			if params:
 				script += "\n@if( peer_description == \"%s\" ) %s\n@endif" % (nn.name, params)


### PR DESCRIPTION
Previously only a subset of config options was available via zeekctl.